### PR TITLE
Clarify the "Don'ts" section about comments and code

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -69,8 +69,8 @@ about: A template PR for code review with a checklist
 
 - [ ] The function's strategy _is not_ described in the documentation
 - [ ] Comments explain the _strategy_, **not** the _implementation_
-- [ ] The function _does not_ have more comments than code
-  - If it does, consider finding a new strategy or a simpler implementation
+- [ ] Having more comments than code in a function
+  - If this occurs, consider finding a new strategy or a simpler implementation
 
 ## Implementation
 


### PR DESCRIPTION
Updated the "Don'ts" section to clarify that having more comments than code indicates the need for a simpler implementation or revised strategy.